### PR TITLE
fix(audiobutton): fix AudioButton state missing when autoplay on ios13

### DIFF
--- a/__test__/H5AudioControls.test.js
+++ b/__test__/H5AudioControls.test.js
@@ -34,6 +34,14 @@ describe('H5AudioControls test', () => {
         }
       });
     };
+
+    // mock canplay
+    window.HTMLMediaElement.prototype.addEventListener = (x, cb) => {
+      if (x !== 'canplay') {
+        return;
+      }
+      cb();
+    };
   });
 
   it('H5AudioControls default test', (done) => {

--- a/src/Audio.js
+++ b/src/Audio.js
@@ -68,6 +68,16 @@ export default class {
   }
 
   /**
+   * canplay
+   * @returns {Promise<>}
+   */
+  canplay() {
+    return new Promise((resolve) => {
+      this.audio.addEventListener('canplay', resolve);
+    });
+  }
+
+  /**
    * init
    * @private
    */

--- a/src/H5AudioControls.js
+++ b/src/H5AudioControls.js
@@ -76,6 +76,9 @@ export default class {
       functionToPromise(() => {
         if (this.config.autoPlay) {
           this.play();
+          this.audioInstance.canplay().then(() => {
+            this.changeButtonUI();
+          });
         }
       })
     );


### PR DESCRIPTION
**Type of Change**
<!-- What type of change does your code introduce? -->
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing or correcting existing tests
- [ ] chore: Changes to the build process or auxiliary tools and libraries such as documentation generation

**Describe Changes**
<!-- Describe your changes in detail, if applicable. -->
fix AudioButton state missing when autoplay on ios13
